### PR TITLE
Story 3.1b: IDLE Connection Pool + Reconnect

### DIFF
--- a/internal/sync/idle.go
+++ b/internal/sync/idle.go
@@ -119,6 +119,10 @@ func NewIdleConnection(ctx context.Context, config IdleConfig) (*IdleConnection,
 }
 
 func (c IdleConfig) validate() error {
+	if c.AccountID == "" {
+		return errors.New("account_id is required")
+	}
+
 	if c.Host == "" {
 		return errors.New("host is required")
 	}

--- a/internal/sync/pool.go
+++ b/internal/sync/pool.go
@@ -239,6 +239,16 @@ func (p *IdlePool) runAccount(entry *accountEntry) {
 		conn, err := NewIdleConnection(p.ctx, entry.config)
 
 		if err != nil {
+			// Non-retryable error - exit goroutine
+			if errors.Is(err, ErrIdleNotSupported) {
+				slog.Warn("account does not support IDLE, giving up",
+					"account_id", entry.config.AccountID,
+					"error", err,
+				)
+
+				return
+			}
+
 			p.handleConnectionError(entry, err)
 
 			select {
@@ -276,10 +286,16 @@ func (p *IdlePool) forwardEvents(entry *accountEntry, conn *IdleConnection) {
 	for {
 		select {
 		case <-entry.stopCh:
+			slog.Debug("stopping event forwarding - account removed",
+				"account_id", entry.config.AccountID,
+			)
 			conn.Close()
 
 			return
 		case <-p.ctx.Done():
+			slog.Debug("stopping event forwarding - pool closing",
+				"account_id", entry.config.AccountID,
+			)
 			conn.Close()
 
 			return
@@ -288,6 +304,7 @@ func (p *IdlePool) forwardEvents(entry *accountEntry, conn *IdleConnection) {
 				slog.Warn("IDLE connection closed unexpectedly",
 					"account_id", entry.config.AccountID,
 				)
+				conn.Close()
 
 				return
 			}
@@ -307,6 +324,7 @@ func (p *IdlePool) forwardEvents(entry *accountEntry, conn *IdleConnection) {
 				slog.Warn("pool event channel full, dropping event",
 					"account_id", entry.config.AccountID,
 					"type", event.Type.String(),
+					"folder", event.Folder,
 				)
 			}
 		}
@@ -314,6 +332,7 @@ func (p *IdlePool) forwardEvents(entry *accountEntry, conn *IdleConnection) {
 }
 
 // handleConnectionError logs the error and updates backoff state.
+// Note: Non-retryable errors (ErrIdleNotSupported) should be handled by caller before this.
 func (p *IdlePool) handleConnectionError(entry *accountEntry, err error) {
 	p.mu.Lock()
 	entry.retryCount++
@@ -325,15 +344,6 @@ func (p *IdlePool) handleConnectionError(entry *accountEntry, err error) {
 	}
 
 	p.mu.Unlock()
-
-	if errors.Is(err, ErrIdleNotSupported) {
-		slog.Warn("account does not support IDLE, will not retry",
-			"account_id", entry.config.AccountID,
-			"error", err,
-		)
-
-		return
-	}
 
 	slog.Warn("IDLE connection failed, will retry",
 		"account_id", entry.config.AccountID,


### PR DESCRIPTION
## Summary
- Add `IdlePool` to manage multiple IDLE connections (one per account)
- Auto-reconnect with exponential backoff on connection failure
- Merge events from all accounts into single channel

## Key Components

| Component | Purpose |
|-----------|---------|
| `IdlePool` | Manages multiple `IdleConnection` instances |
| `AddAccount()` | Add account and start IDLE connection |
| `RemoveAccount()` | Stop connection and remove account |
| `Events()` | Merged event channel from all accounts |
| `AccountStatus()` | Check connection status and retry count |

## Reconnection Strategy
- Initial backoff: 1 second
- Backoff multiplier: 2x
- Max backoff: 5 minutes
- Special case: `ErrIdleNotSupported` logs warning but doesn't retry (server doesn't support IDLE)

## Changes to idle.go
- Added `AccountID` field to `IdleConfig` and `IdleEvent` for routing

## Acceptance Criteria
- [x] Connection drop -> auto-reconnect with backoff
- [x] Add account -> starts IDLE
- [x] Remove account -> closes connection
- [x] Health check logging
- [x] Build passes
- [x] Tests pass

## Dependencies
- Depends on: Story 3.1a (Single IDLE Connection) - completed
- Blocks: Story 3.3 (Sync Coordinator)