### PR TITLE
Fix ListEmails deleted filter and align presigned URL expiry

### DIFF
--- a/internal/db/emails.sql.go
+++ b/internal/db/emails.sql.go
@@ -227,6 +227,7 @@ const listEmails = `-- name: ListEmails :many
 SELECT id, account_id, uid, message_id, folder, subject, from_email, from_name, date, parsed_text, parsed_html, raw, flags, deleted_upstream, search_vector, created_at, to_recipients, cc_recipients FROM emails
 WHERE account_id = $1
   AND folder = $2
+  AND deleted_upstream = false
   AND ($5::timestamptz IS NULL OR date < $5)
   AND ($6::timestamptz IS NULL OR date > $6)
 ORDER BY date DESC

--- a/internal/db/queries/emails.sql
+++ b/internal/db/queries/emails.sql
@@ -18,6 +18,7 @@ WHERE account_id = $1 AND folder = $2 AND uid = $3;
 SELECT * FROM emails
 WHERE account_id = $1
   AND folder = $2
+  AND deleted_upstream = false
   AND (sqlc.narg('before')::timestamptz IS NULL OR date < sqlc.narg('before'))
   AND (sqlc.narg('after')::timestamptz IS NULL OR date > sqlc.narg('after'))
 ORDER BY date DESC

--- a/internal/webhook/producer.go
+++ b/internal/webhook/producer.go
@@ -18,7 +18,8 @@ import (
 
 const (
 	// PresignedURLExpiry is how long presigned URLs are valid for.
-	PresignedURLExpiry = 24 * time.Hour
+	// Using 1 hour to match API expiry and limit exposure if URL leaks.
+	PresignedURLExpiry = 1 * time.Hour
 )
 
 // WebhookPayload is the JSON structure sent to webhook endpoints.


### PR DESCRIPTION
## Summary
Quick wins from codebase review - two bug fixes.

## Fixes

### 1. ListEmails now excludes deleted emails
**File:** `internal/db/queries/emails.sql`

Added `AND deleted_upstream = false` to ListEmails query.

**Before:** Count returned N, List returned N + deleted emails
**After:** Both are consistent

### 2. Presigned URL expiry aligned
**File:** `internal/webhook/producer.go`

Changed from 24 hours to 1 hour to match API handler expiry.

**Rationale:** Shorter expiry = less risk if URL leaks. Webhook receivers should process quickly anyway.

## Testing
- `make build` passes
- `make test` passes