### PR TITLE
Story 6.1: Structured Logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,10 @@ LETTERBOX_DATABASE_URL=postgres://letterbox:letterbox@localhost:5434/letterbox?s
 # Generate: openssl rand -hex 32
 LETTERBOX_ENCRYPTION_KEY=
 
+# API key for authentication (required)
+# Generate: openssl rand -hex 32
+LETTERBOX_API_KEY=
+
 # S3-compatible storage (required)
 # Local Minio: http://localhost:9000
 # Cloudflare R2: https://<account>.r2.cloudflarestorage.com
@@ -19,3 +23,9 @@ LETTERBOX_S3_BUCKET=letterbox
 LETTERBOX_S3_ACCESS_KEY=minioadmin
 LETTERBOX_S3_SECRET_KEY=minioadmin
 LETTERBOX_S3_REGION=auto
+
+# Logging configuration
+# Level: debug, info, warn, error (default: info)
+LETTERBOX_LOG_LEVEL=info
+# Format: json, text (default: json)
+LETTERBOX_LOG_FORMAT=json

--- a/cmd/letterbox/main.go
+++ b/cmd/letterbox/main.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"log/slog"
 	"net/http"
-	"os"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -13,20 +12,23 @@ import (
 	"github.com/oladayo21/letterbox/internal/config"
 	"github.com/oladayo21/letterbox/internal/db"
 	"github.com/oladayo21/letterbox/internal/ingest"
+	"github.com/oladayo21/letterbox/internal/logging"
 	"github.com/oladayo21/letterbox/internal/repository"
 	"github.com/oladayo21/letterbox/internal/search"
 	"github.com/oladayo21/letterbox/internal/storage"
 )
 
 func main() {
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
-	slog.SetDefault(logger)
-
 	cfg, err := config.Load()
 
 	if err != nil {
 		log.Fatalf("config error: %v", err)
 	}
+
+	logging.Setup(logging.Config{
+		Level:  cfg.LogLevel,
+		Format: cfg.LogFormat,
+	})
 
 	ctx := context.Background()
 	pool, err := pgxpool.New(ctx, cfg.DatabaseURL)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -5,6 +5,7 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 
 	"github.com/oladayo21/letterbox/internal/ingest"
+	"github.com/oladayo21/letterbox/internal/logging"
 	"github.com/oladayo21/letterbox/internal/repository"
 	"github.com/oladayo21/letterbox/internal/search"
 	"github.com/oladayo21/letterbox/internal/storage"
@@ -22,7 +23,7 @@ func NewRouter(
 ) *chi.Mux {
 	r := chi.NewRouter()
 
-	r.Use(middleware.Logger)
+	r.Use(logging.RequestLogger)
 	r.Use(middleware.Recoverer)
 	r.Use(APIKeyAuth(apiKey))
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,8 @@ type Config struct {
 	S3AccessKey   string `envconfig:"S3_ACCESS_KEY" required:"true"`
 	S3SecretKey   string `envconfig:"S3_SECRET_KEY" required:"true"`
 	S3Region      string `envconfig:"S3_REGION" default:"auto"`
+	LogLevel      string `envconfig:"LOG_LEVEL" default:"info"`
+	LogFormat     string `envconfig:"LOG_FORMAT" default:"json"`
 
 	encryptionKeyBytes []byte
 }

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,53 @@
+package logging
+
+import (
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// Config contains logging configuration.
+type Config struct {
+	Level  string // debug, info, warn, error
+	Format string // json, text
+}
+
+// Setup configures the default slog logger based on config.
+// Returns the configured logger.
+func Setup(cfg Config) *slog.Logger {
+	level := parseLevel(cfg.Level)
+
+	opts := &slog.HandlerOptions{
+		Level: level,
+	}
+
+	var handler slog.Handler
+
+	if strings.ToLower(cfg.Format) == "text" {
+		handler = slog.NewTextHandler(os.Stdout, opts)
+	} else {
+		handler = slog.NewJSONHandler(os.Stdout, opts)
+	}
+
+	logger := slog.New(handler)
+	slog.SetDefault(logger)
+
+	return logger
+}
+
+// parseLevel converts a string level to slog.Level.
+// Defaults to Info if unrecognized.
+func parseLevel(level string) slog.Level {
+	switch strings.ToLower(level) {
+	case "debug":
+		return slog.LevelDebug
+	case "info":
+		return slog.LevelInfo
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}

--- a/internal/logging/middleware.go
+++ b/internal/logging/middleware.go
@@ -1,0 +1,64 @@
+package logging
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// responseWriter wraps http.ResponseWriter to capture status code.
+type responseWriter struct {
+	http.ResponseWriter
+	status      int
+	wroteHeader bool
+}
+
+func wrapResponseWriter(w http.ResponseWriter) *responseWriter {
+	return &responseWriter{ResponseWriter: w, status: http.StatusOK}
+}
+
+func (rw *responseWriter) WriteHeader(code int) {
+	if rw.wroteHeader {
+		return
+	}
+
+	rw.status = code
+	rw.wroteHeader = true
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+func (rw *responseWriter) Write(b []byte) (int, error) {
+	if !rw.wroteHeader {
+		rw.WriteHeader(http.StatusOK)
+	}
+
+	return rw.ResponseWriter.Write(b)
+}
+
+// RequestLogger returns a middleware that logs HTTP requests using slog.
+func RequestLogger(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+
+		wrapped := wrapResponseWriter(w)
+		next.ServeHTTP(wrapped, r)
+
+		duration := time.Since(start)
+
+		level := slog.LevelInfo
+
+		if wrapped.status >= 500 {
+			level = slog.LevelError
+		} else if wrapped.status >= 400 {
+			level = slog.LevelWarn
+		}
+
+		slog.Log(r.Context(), level, "http request",
+			"method", r.Method,
+			"path", r.URL.Path,
+			"status", wrapped.status,
+			"duration_ms", duration.Milliseconds(),
+			"remote_addr", r.RemoteAddr,
+		)
+	})
+}


### PR DESCRIPTION
## Summary
- Add `internal/logging` package with slog-based structured logging
- Add configurable log level (debug/info/warn/error) via `LETTERBOX_LOG_LEVEL`
- Add configurable log format (json/text) via `LETTERBOX_LOG_FORMAT`
- Add request logging middleware capturing method, path, status, duration_ms, remote_addr
- Replace chi's built-in logger with structured slog middleware

## Changes
- `internal/logging/logging.go` - slog setup with level/format configuration
- `internal/logging/middleware.go` - HTTP request logging middleware
- `internal/config/config.go` - add LogLevel and LogFormat config fields
- `internal/api/router.go` - use new logging middleware
- `cmd/letterbox/main.go` - initialize logging from config
- `.env.example` - document new env vars

## Testing
- `make build` - passes
- `make test` - all tests pass

## Acceptance Criteria
- [x] All operations logged with context
- [x] JSON output for production (default)
- [x] Text output option for development
- [x] Request logging middleware with method, path, status, duration