### PR TITLE
Story 6.2: Health Endpoints

### DIFF
--- a/cmd/letterbox/main.go
+++ b/cmd/letterbox/main.go
@@ -84,7 +84,17 @@ func main() {
 	// Initialize search service
 	searchSvc := search.NewService(emailRepo)
 
-	router := api.NewRouter(cfg.APIKey, accountRepo, emailRepo, attachmentRepo, webhookRepo, ingester, s3Storage, searchSvc)
+	router := api.NewRouter(api.RouterConfig{
+		APIKey:         cfg.APIKey,
+		AccountRepo:    accountRepo,
+		EmailRepo:      emailRepo,
+		AttachmentRepo: attachmentRepo,
+		WebhookRepo:    webhookRepo,
+		Ingester:       ingester,
+		S3:             s3Storage,
+		SearchSvc:      searchSvc,
+		DB:             pool,
+	})
 
 	slog.Info("letterbox starting", "port", cfg.Port)
 	log.Fatal(http.ListenAndServe(":"+cfg.Port, router))

--- a/internal/api/health_handler.go
+++ b/internal/api/health_handler.go
@@ -1,0 +1,76 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+// HealthChecker defines the interface for checking component health.
+type HealthChecker interface {
+	// Ping checks if the component is healthy.
+	// Returns nil if healthy, error otherwise.
+	Ping(ctx context.Context) error
+}
+
+// HealthHandler handles health check endpoints.
+type HealthHandler struct {
+	db      HealthChecker
+	s3      HealthChecker
+	timeout time.Duration
+}
+
+// NewHealthHandler creates a new health handler.
+func NewHealthHandler(db, s3 HealthChecker) *HealthHandler {
+	return &HealthHandler{
+		db:      db,
+		s3:      s3,
+		timeout: 5 * time.Second,
+	}
+}
+
+// Health is a basic liveness check - returns 200 if the process is alive.
+// GET /health
+func (h *HealthHandler) Health(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]string{
+		"status": "ok",
+	})
+}
+
+// Ready is a readiness check - returns 200 if all dependencies are healthy.
+// GET /ready
+func (h *HealthHandler) Ready(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), h.timeout)
+	defer cancel()
+
+	checks := make(map[string]string)
+	allHealthy := true
+
+	// Check database
+	if err := h.db.Ping(ctx); err != nil {
+		checks["database"] = err.Error()
+		allHealthy = false
+	} else {
+		checks["database"] = "ok"
+	}
+
+	// Check S3
+	if err := h.s3.Ping(ctx); err != nil {
+		checks["s3"] = err.Error()
+		allHealthy = false
+	} else {
+		checks["s3"] = "ok"
+	}
+
+	response := map[string]interface{}{
+		"checks": checks,
+	}
+
+	if allHealthy {
+		response["status"] = "ok"
+		writeJSON(w, http.StatusOK, response)
+	} else {
+		response["status"] = "unhealthy"
+		writeJSON(w, http.StatusServiceUnavailable, response)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -11,45 +11,59 @@ import (
 	"github.com/oladayo21/letterbox/internal/storage"
 )
 
-func NewRouter(
-	apiKey string,
-	accountRepo *repository.AccountRepository,
-	emailRepo *repository.EmailRepository,
-	attachmentRepo *repository.AttachmentRepository,
-	webhookRepo *repository.WebhookRepository,
-	ingester *ingest.Ingester,
-	s3 *storage.S3Storage,
-	searchSvc *search.Service,
-) *chi.Mux {
+// RouterConfig contains dependencies for the router.
+type RouterConfig struct {
+	APIKey         string
+	AccountRepo    *repository.AccountRepository
+	EmailRepo      *repository.EmailRepository
+	AttachmentRepo *repository.AttachmentRepository
+	WebhookRepo    *repository.WebhookRepository
+	Ingester       *ingest.Ingester
+	S3             *storage.S3Storage
+	SearchSvc      *search.Service
+	DB             HealthChecker
+}
+
+func NewRouter(cfg RouterConfig) *chi.Mux {
 	r := chi.NewRouter()
 
+	// Global middleware
 	r.Use(logging.RequestLogger)
 	r.Use(middleware.Recoverer)
-	r.Use(APIKeyAuth(apiKey))
 
-	accountHandler := NewAccountHandler(accountRepo)
-	folderHandler := NewFolderHandler(accountRepo)
-	messageHandler := NewMessageHandler(accountRepo, emailRepo, attachmentRepo, ingester, s3)
-	webhookHandler := NewWebhookHandler(webhookRepo)
-	searchHandler := NewSearchHandler(accountRepo, searchSvc)
+	// Health endpoints (unauthenticated)
+	healthHandler := NewHealthHandler(cfg.DB, cfg.S3)
+	r.Get("/health", healthHandler.Health)
+	r.Get("/ready", healthHandler.Ready)
 
-	r.Route("/accounts", func(r chi.Router) {
-		r.Post("/", accountHandler.Create)
-		r.Get("/", accountHandler.List)
-		r.Get("/{id}", accountHandler.Get)
-		r.Delete("/{id}", accountHandler.Delete)
-		r.Get("/{id}/folders", folderHandler.List)
-		r.Get("/{id}/folders/{name}/messages", messageHandler.ListMessages)
-		r.Get("/{id}/messages/{uid}", messageHandler.GetMessage)
+	// Protected routes
+	r.Group(func(r chi.Router) {
+		r.Use(APIKeyAuth(cfg.APIKey))
+
+		accountHandler := NewAccountHandler(cfg.AccountRepo)
+		folderHandler := NewFolderHandler(cfg.AccountRepo)
+		messageHandler := NewMessageHandler(cfg.AccountRepo, cfg.EmailRepo, cfg.AttachmentRepo, cfg.Ingester, cfg.S3)
+		webhookHandler := NewWebhookHandler(cfg.WebhookRepo)
+		searchHandler := NewSearchHandler(cfg.AccountRepo, cfg.SearchSvc)
+
+		r.Route("/accounts", func(r chi.Router) {
+			r.Post("/", accountHandler.Create)
+			r.Get("/", accountHandler.List)
+			r.Get("/{id}", accountHandler.Get)
+			r.Delete("/{id}", accountHandler.Delete)
+			r.Get("/{id}/folders", folderHandler.List)
+			r.Get("/{id}/folders/{name}/messages", messageHandler.ListMessages)
+			r.Get("/{id}/messages/{uid}", messageHandler.GetMessage)
+		})
+
+		r.Route("/webhooks", func(r chi.Router) {
+			r.Post("/", webhookHandler.Create)
+			r.Get("/", webhookHandler.List)
+			r.Delete("/{id}", webhookHandler.Delete)
+		})
+
+		r.Get("/search", searchHandler.Search)
 	})
-
-	r.Route("/webhooks", func(r chi.Router) {
-		r.Post("/", webhookHandler.Create)
-		r.Get("/", webhookHandler.List)
-		r.Delete("/{id}", webhookHandler.Delete)
-	})
-
-	r.Get("/search", searchHandler.Search)
 
 	return r
 }

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -164,3 +164,18 @@ func (s *S3Storage) Bucket() string {
 
 	return s.bucket
 }
+
+// Ping checks if the S3 storage is accessible by verifying bucket access.
+func (s *S3Storage) Ping(ctx context.Context) error {
+	input := &s3.HeadBucketInput{
+		Bucket: aws.String(s.bucket),
+	}
+
+	_, err := s.client.HeadBucket(ctx, input)
+
+	if err != nil {
+		return fmt.Errorf("S3 bucket not accessible: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary
- Add `GET /health` liveness endpoint (always returns 200)
- Add `GET /ready` readiness endpoint (checks DB + S3 connectivity)
- Health endpoints are unauthenticated for Kubernetes/Docker probes

## Changes
- `internal/api/health_handler.go` - new health handler with HealthChecker interface
- `internal/api/router.go` - refactor to use RouterConfig, add health routes outside auth middleware
- `internal/storage/s3.go` - add Ping method for health checks
- `cmd/letterbox/main.go` - pass DB pool to router config

## API Responses

### GET /health
```json
{"status": "ok"}
```

### GET /ready (healthy)
```json
{
  "status": "ok",
  "checks": {
    "database": "ok",
    "s3": "ok"
  }
}
```

### GET /ready (unhealthy - 503)
```json
{
  "status": "unhealthy",
  "checks": {
    "database": "ok",
    "s3": "S3 bucket not accessible: ..."
  }
}
```

## Testing
- `make build` - passes
- `make test` - all tests pass

## Acceptance Criteria
- [x] `/health` returns 200 if process alive
- [x] `/ready` returns 503 if any dependency down
- [x] Health endpoints work without API key