### PR TITLE
Story 7.3: Compose Email Model

### DIFF
--- a/internal/composer/composer.go
+++ b/internal/composer/composer.go
@@ -8,17 +8,21 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jhillyerd/enmime/v2"
 
 	"github.com/oladayo21/letterbox/internal/domain"
 )
 
 var (
-	ErrNoRecipients = errors.New("at least one recipient is required")
-	ErrNoFrom       = errors.New("from address is required")
-	ErrInvalidEmail = errors.New("invalid email address")
-	ErrNoSubject    = errors.New("subject is required")
-	ErrNoBody       = errors.New("at least text or html body is required")
+	ErrNoRecipients     = errors.New("at least one recipient is required")
+	ErrNoFrom           = errors.New("from address is required")
+	ErrInvalidEmail     = errors.New("invalid email address")
+	ErrNoSubject        = errors.New("subject is required")
+	ErrNoBody           = errors.New("at least text or html body is required")
+	ErrInvalidSubject   = errors.New("subject contains invalid characters")
+	ErrInvalidMessageID = errors.New("invalid message-id format")
+	ErrMissingContentID = errors.New("inline attachments require a ContentID")
 )
 
 // Attachment represents a file to attach to an email.
@@ -82,8 +86,32 @@ func (e *ComposeEmail) Validate() error {
 		return ErrNoSubject
 	}
 
+	// Prevent header injection via subject
+	if strings.ContainsAny(e.Subject, "\r\n") {
+		return ErrInvalidSubject
+	}
+
 	if e.Text == "" && e.HTML == "" {
 		return ErrNoBody
+	}
+
+	// Validate InReplyTo format if provided
+	if e.InReplyTo != "" && !isValidMessageID(e.InReplyTo) {
+		return fmt.Errorf("%w: in-reply-to: %s", ErrInvalidMessageID, e.InReplyTo)
+	}
+
+	// Validate References format if provided
+	for _, ref := range e.References {
+		if !isValidMessageID(ref) {
+			return fmt.Errorf("%w: references: %s", ErrInvalidMessageID, ref)
+		}
+	}
+
+	// Validate inline attachments have ContentID
+	for _, att := range e.Attachments {
+		if att.IsInline && att.ContentID == "" {
+			return ErrMissingContentID
+		}
 	}
 
 	return nil
@@ -96,10 +124,14 @@ func (e *ComposeEmail) Build() ([]byte, error) {
 		return nil, err
 	}
 
+	// Generate unique Message-ID
+	msgID := fmt.Sprintf("<%s@letterbox>", uuid.NewString())
+
 	builder := enmime.Builder().
 		From(e.From.Name, e.From.Email).
 		Subject(e.Subject).
-		Date(time.Now())
+		Date(time.Now()).
+		Header("Message-Id", msgID)
 
 	// Add recipients
 	for _, addr := range e.To {
@@ -188,4 +220,22 @@ func (e *ComposeEmail) AllRecipients() []string {
 func validateEmail(email string) error {
 	_, err := mail.ParseAddress(email)
 	return err
+}
+
+// isValidMessageID checks if a string is a valid Message-ID format.
+// Message-IDs should be enclosed in angle brackets: <id@domain>
+func isValidMessageID(id string) bool {
+	if len(id) < 5 { // Minimum: <a@b>
+		return false
+	}
+
+	if !strings.HasPrefix(id, "<") || !strings.HasSuffix(id, ">") {
+		return false
+	}
+
+	// Check there's something before and after the @
+	inner := id[1 : len(id)-1] // Remove angle brackets
+	atIdx := strings.Index(inner, "@")
+
+	return atIdx > 0 && atIdx < len(inner)-1
 }

--- a/internal/composer/composer.go
+++ b/internal/composer/composer.go
@@ -1,0 +1,191 @@
+package composer
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"net/mail"
+	"strings"
+	"time"
+
+	"github.com/jhillyerd/enmime/v2"
+
+	"github.com/oladayo21/letterbox/internal/domain"
+)
+
+var (
+	ErrNoRecipients = errors.New("at least one recipient is required")
+	ErrNoFrom       = errors.New("from address is required")
+	ErrInvalidEmail = errors.New("invalid email address")
+	ErrNoSubject    = errors.New("subject is required")
+	ErrNoBody       = errors.New("at least text or html body is required")
+)
+
+// Attachment represents a file to attach to an email.
+type Attachment struct {
+	Filename    string
+	ContentType string
+	Data        []byte
+	IsInline    bool
+	ContentID   string // For inline images, used in HTML as cid:ContentID
+}
+
+// ComposeEmail represents an email to be sent.
+type ComposeEmail struct {
+	From        domain.EmailAddress
+	To          []domain.EmailAddress
+	CC          []domain.EmailAddress
+	BCC         []domain.EmailAddress
+	Subject     string
+	Text        string
+	HTML        string
+	Attachments []Attachment
+
+	// For replies/forwards
+	InReplyTo  string   // Message-ID of the email being replied to
+	References []string // Chain of Message-IDs for threading
+}
+
+// Validate checks that the email has all required fields and valid addresses.
+func (e *ComposeEmail) Validate() error {
+	if e.From.Email == "" {
+		return ErrNoFrom
+	}
+
+	if err := validateEmail(e.From.Email); err != nil {
+		return fmt.Errorf("%w: from: %s", ErrInvalidEmail, e.From.Email)
+	}
+
+	if len(e.To) == 0 && len(e.CC) == 0 && len(e.BCC) == 0 {
+		return ErrNoRecipients
+	}
+
+	for _, addr := range e.To {
+		if err := validateEmail(addr.Email); err != nil {
+			return fmt.Errorf("%w: to: %s", ErrInvalidEmail, addr.Email)
+		}
+	}
+
+	for _, addr := range e.CC {
+		if err := validateEmail(addr.Email); err != nil {
+			return fmt.Errorf("%w: cc: %s", ErrInvalidEmail, addr.Email)
+		}
+	}
+
+	for _, addr := range e.BCC {
+		if err := validateEmail(addr.Email); err != nil {
+			return fmt.Errorf("%w: bcc: %s", ErrInvalidEmail, addr.Email)
+		}
+	}
+
+	if e.Subject == "" {
+		return ErrNoSubject
+	}
+
+	if e.Text == "" && e.HTML == "" {
+		return ErrNoBody
+	}
+
+	return nil
+}
+
+// Build creates an RFC 2822 compliant email message.
+// Returns the raw message bytes ready for sending via SMTP.
+func (e *ComposeEmail) Build() ([]byte, error) {
+	if err := e.Validate(); err != nil {
+		return nil, err
+	}
+
+	builder := enmime.Builder().
+		From(e.From.Name, e.From.Email).
+		Subject(e.Subject).
+		Date(time.Now())
+
+	// Add recipients
+	for _, addr := range e.To {
+		builder = builder.To(addr.Name, addr.Email)
+	}
+
+	for _, addr := range e.CC {
+		builder = builder.CC(addr.Name, addr.Email)
+	}
+
+	for _, addr := range e.BCC {
+		builder = builder.BCC(addr.Name, addr.Email)
+	}
+
+	// Add body - enmime handles multipart/alternative automatically
+	if e.Text != "" {
+		builder = builder.Text([]byte(e.Text))
+	}
+
+	if e.HTML != "" {
+		builder = builder.HTML([]byte(e.HTML))
+	}
+
+	// Add threading headers for replies
+	if e.InReplyTo != "" {
+		builder = builder.Header("In-Reply-To", e.InReplyTo)
+	}
+
+	if len(e.References) > 0 {
+		builder = builder.Header("References", strings.Join(e.References, " "))
+	}
+
+	// Add attachments
+	for _, att := range e.Attachments {
+		if att.IsInline {
+			builder = builder.AddInline(
+				att.Data,
+				att.ContentType,
+				att.Filename,
+				att.ContentID,
+			)
+		} else {
+			builder = builder.AddAttachment(
+				att.Data,
+				att.ContentType,
+				att.Filename,
+			)
+		}
+	}
+
+	// Build the message
+	part, err := builder.Build()
+	if err != nil {
+		return nil, fmt.Errorf("building email: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := part.Encode(&buf); err != nil {
+		return nil, fmt.Errorf("encoding email: %w", err)
+	}
+
+	return buf.Bytes(), nil
+}
+
+// AllRecipients returns all recipient email addresses (To + CC + BCC).
+// This is useful for SMTP RCPT TO commands.
+func (e *ComposeEmail) AllRecipients() []string {
+	var recipients []string
+
+	for _, addr := range e.To {
+		recipients = append(recipients, addr.Email)
+	}
+
+	for _, addr := range e.CC {
+		recipients = append(recipients, addr.Email)
+	}
+
+	for _, addr := range e.BCC {
+		recipients = append(recipients, addr.Email)
+	}
+
+	return recipients
+}
+
+// validateEmail checks if an email address is valid.
+func validateEmail(email string) error {
+	_, err := mail.ParseAddress(email)
+	return err
+}

--- a/internal/composer/composer_test.go
+++ b/internal/composer/composer_test.go
@@ -110,6 +110,62 @@ func TestComposeEmail_Validate(t *testing.T) {
 			},
 			wantErr: ErrNoBody,
 		},
+		{
+			name: "invalid cc email",
+			email: ComposeEmail{
+				From:    domain.EmailAddress{Email: "sender@test.com"},
+				To:      []domain.EmailAddress{{Email: "valid@test.com"}},
+				CC:      []domain.EmailAddress{{Email: "bad-cc-email"}},
+				Subject: "Test",
+				Text:    "Hello",
+			},
+			wantErr: ErrInvalidEmail,
+		},
+		{
+			name: "invalid bcc email",
+			email: ComposeEmail{
+				From:    domain.EmailAddress{Email: "sender@test.com"},
+				To:      []domain.EmailAddress{{Email: "valid@test.com"}},
+				BCC:     []domain.EmailAddress{{Email: "bad-bcc-email"}},
+				Subject: "Test",
+				Text:    "Hello",
+			},
+			wantErr: ErrInvalidEmail,
+		},
+		{
+			name: "subject with newline (header injection)",
+			email: ComposeEmail{
+				From:    domain.EmailAddress{Email: "sender@test.com"},
+				To:      []domain.EmailAddress{{Email: "recipient@test.com"}},
+				Subject: "Test\r\nBcc: attacker@evil.com",
+				Text:    "Hello",
+			},
+			wantErr: ErrInvalidSubject,
+		},
+		{
+			name: "invalid in-reply-to format",
+			email: ComposeEmail{
+				From:      domain.EmailAddress{Email: "sender@test.com"},
+				To:        []domain.EmailAddress{{Email: "recipient@test.com"}},
+				Subject:   "Re: Test",
+				Text:      "Hello",
+				InReplyTo: "not-a-valid-message-id",
+			},
+			wantErr: ErrInvalidMessageID,
+		},
+		{
+			name: "inline attachment without content-id",
+			email: ComposeEmail{
+				From:    domain.EmailAddress{Email: "sender@test.com"},
+				To:      []domain.EmailAddress{{Email: "recipient@test.com"}},
+				Subject: "Test",
+				HTML:    "<img src='cid:missing'>",
+				Attachments: []Attachment{
+					{Filename: "img.png", ContentType: "image/png", Data: []byte{1}, IsInline: true, ContentID: ""},
+				},
+			},
+			wantErr: ErrMissingContentID,
+		},
 	}
 
 	for _, tt := range tests {
@@ -161,6 +217,11 @@ func TestComposeEmail_Build_PlainText(t *testing.T) {
 
 	if !strings.Contains(msgStr, "Subject: Test Subject") {
 		t.Error("missing or incorrect Subject header")
+	}
+
+	// Check Message-ID is generated
+	if !strings.Contains(msgStr, "Message-Id:") || !strings.Contains(msgStr, "@letterbox>") {
+		t.Error("missing or incorrect Message-Id header")
 	}
 
 	// Check body
@@ -332,6 +393,31 @@ func TestValidateEmail(t *testing.T) {
 			}
 			if !tt.isValid && err == nil {
 				t.Errorf("expected %q to be invalid", tt.email)
+			}
+		})
+	}
+}
+
+func TestIsValidMessageID(t *testing.T) {
+	tests := []struct {
+		id      string
+		isValid bool
+	}{
+		{"<abc123@example.com>", true},
+		{"<unique-id@letterbox>", true},
+		{"<123.456@domain.org>", true},
+		{"abc123@example.com", false}, // missing angle brackets
+		{"<abc123>", false},           // missing @
+		{"<>", false},                 // empty
+		{"", false},                   // empty string
+		{"<@domain>", false},          // missing local part (too short)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.id, func(t *testing.T) {
+			result := isValidMessageID(tt.id)
+			if result != tt.isValid {
+				t.Errorf("isValidMessageID(%q) = %v, want %v", tt.id, result, tt.isValid)
 			}
 		})
 	}

--- a/internal/composer/composer_test.go
+++ b/internal/composer/composer_test.go
@@ -1,0 +1,338 @@
+package composer
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/oladayo21/letterbox/internal/domain"
+)
+
+func TestComposeEmail_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		email   ComposeEmail
+		wantErr error
+	}{
+		{
+			name: "valid plain text email",
+			email: ComposeEmail{
+				From:    domain.EmailAddress{Email: "sender@test.com"},
+				To:      []domain.EmailAddress{{Email: "recipient@test.com"}},
+				Subject: "Test",
+				Text:    "Hello",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "valid html email",
+			email: ComposeEmail{
+				From:    domain.EmailAddress{Email: "sender@test.com"},
+				To:      []domain.EmailAddress{{Email: "recipient@test.com"}},
+				Subject: "Test",
+				HTML:    "<p>Hello</p>",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "valid email with CC only",
+			email: ComposeEmail{
+				From:    domain.EmailAddress{Email: "sender@test.com"},
+				CC:      []domain.EmailAddress{{Email: "cc@test.com"}},
+				Subject: "Test",
+				Text:    "Hello",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "valid email with BCC only",
+			email: ComposeEmail{
+				From:    domain.EmailAddress{Email: "sender@test.com"},
+				BCC:     []domain.EmailAddress{{Email: "bcc@test.com"}},
+				Subject: "Test",
+				Text:    "Hello",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "missing from",
+			email: ComposeEmail{
+				To:      []domain.EmailAddress{{Email: "recipient@test.com"}},
+				Subject: "Test",
+				Text:    "Hello",
+			},
+			wantErr: ErrNoFrom,
+		},
+		{
+			name: "invalid from email",
+			email: ComposeEmail{
+				From:    domain.EmailAddress{Email: "not-an-email"},
+				To:      []domain.EmailAddress{{Email: "recipient@test.com"}},
+				Subject: "Test",
+				Text:    "Hello",
+			},
+			wantErr: ErrInvalidEmail,
+		},
+		{
+			name: "no recipients",
+			email: ComposeEmail{
+				From:    domain.EmailAddress{Email: "sender@test.com"},
+				Subject: "Test",
+				Text:    "Hello",
+			},
+			wantErr: ErrNoRecipients,
+		},
+		{
+			name: "invalid to email",
+			email: ComposeEmail{
+				From:    domain.EmailAddress{Email: "sender@test.com"},
+				To:      []domain.EmailAddress{{Email: "bad-email"}},
+				Subject: "Test",
+				Text:    "Hello",
+			},
+			wantErr: ErrInvalidEmail,
+		},
+		{
+			name: "missing subject",
+			email: ComposeEmail{
+				From: domain.EmailAddress{Email: "sender@test.com"},
+				To:   []domain.EmailAddress{{Email: "recipient@test.com"}},
+				Text: "Hello",
+			},
+			wantErr: ErrNoSubject,
+		},
+		{
+			name: "missing body",
+			email: ComposeEmail{
+				From:    domain.EmailAddress{Email: "sender@test.com"},
+				To:      []domain.EmailAddress{{Email: "recipient@test.com"}},
+				Subject: "Test",
+			},
+			wantErr: ErrNoBody,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.email.Validate()
+
+			if tt.wantErr == nil {
+				if err != nil {
+					t.Errorf("expected no error, got %v", err)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Errorf("expected error %v, got nil", tt.wantErr)
+				return
+			}
+
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("expected error %v, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestComposeEmail_Build_PlainText(t *testing.T) {
+	email := ComposeEmail{
+		From:    domain.EmailAddress{Name: "Sender", Email: "sender@test.com"},
+		To:      []domain.EmailAddress{{Name: "Recipient", Email: "recipient@test.com"}},
+		Subject: "Test Subject",
+		Text:    "Hello, World!",
+	}
+
+	msg, err := email.Build()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	msgStr := string(msg)
+
+	// Check headers - enmime uses quoted format
+	if !strings.Contains(msgStr, "From:") || !strings.Contains(msgStr, "sender@test.com") {
+		t.Errorf("missing or incorrect From header, got: %s", msgStr)
+	}
+
+	if !strings.Contains(msgStr, "To:") || !strings.Contains(msgStr, "recipient@test.com") {
+		t.Errorf("missing or incorrect To header, got: %s", msgStr)
+	}
+
+	if !strings.Contains(msgStr, "Subject: Test Subject") {
+		t.Error("missing or incorrect Subject header")
+	}
+
+	// Check body
+	if !strings.Contains(msgStr, "Hello, World!") {
+		t.Error("missing body content")
+	}
+}
+
+func TestComposeEmail_Build_HTMLAndText(t *testing.T) {
+	email := ComposeEmail{
+		From:    domain.EmailAddress{Email: "sender@test.com"},
+		To:      []domain.EmailAddress{{Email: "recipient@test.com"}},
+		Subject: "Test",
+		Text:    "Plain text version",
+		HTML:    "<p>HTML version</p>",
+	}
+
+	msg, err := email.Build()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	msgStr := string(msg)
+
+	// Should be multipart/alternative
+	if !strings.Contains(msgStr, "multipart/alternative") {
+		t.Error("expected multipart/alternative for text+html email")
+	}
+
+	if !strings.Contains(msgStr, "Plain text version") {
+		t.Error("missing plain text content")
+	}
+
+	if !strings.Contains(msgStr, "<p>HTML version</p>") {
+		t.Error("missing HTML content")
+	}
+}
+
+func TestComposeEmail_Build_WithAttachment(t *testing.T) {
+	email := ComposeEmail{
+		From:    domain.EmailAddress{Email: "sender@test.com"},
+		To:      []domain.EmailAddress{{Email: "recipient@test.com"}},
+		Subject: "Test with attachment",
+		Text:    "See attached file",
+		Attachments: []Attachment{
+			{
+				Filename:    "test.txt",
+				ContentType: "text/plain",
+				Data:        []byte("file content"),
+				IsInline:    false,
+			},
+		},
+	}
+
+	msg, err := email.Build()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	msgStr := string(msg)
+
+	// Should be multipart/mixed for attachments
+	if !strings.Contains(msgStr, "multipart/mixed") {
+		t.Error("expected multipart/mixed for email with attachment")
+	}
+
+	if !strings.Contains(msgStr, "test.txt") {
+		t.Error("missing attachment filename")
+	}
+}
+
+func TestComposeEmail_Build_WithInlineImage(t *testing.T) {
+	email := ComposeEmail{
+		From:    domain.EmailAddress{Email: "sender@test.com"},
+		To:      []domain.EmailAddress{{Email: "recipient@test.com"}},
+		Subject: "Test with inline image",
+		HTML:    `<p>Image: <img src="cid:image1"></p>`,
+		Attachments: []Attachment{
+			{
+				Filename:    "image.png",
+				ContentType: "image/png",
+				Data:        []byte{0x89, 0x50, 0x4E, 0x47}, // PNG magic bytes
+				IsInline:    true,
+				ContentID:   "image1",
+			},
+		},
+	}
+
+	msg, err := email.Build()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	msgStr := string(msg)
+
+	// Check that the inline image is present (enmime may format Content-ID differently)
+	if !strings.Contains(msgStr, "image.png") && !strings.Contains(msgStr, "image/png") {
+		t.Errorf("missing inline image, got: %s", msgStr)
+	}
+}
+
+func TestComposeEmail_Build_WithReplyHeaders(t *testing.T) {
+	email := ComposeEmail{
+		From:       domain.EmailAddress{Email: "sender@test.com"},
+		To:         []domain.EmailAddress{{Email: "recipient@test.com"}},
+		Subject:    "Re: Original Subject",
+		Text:       "My reply",
+		InReplyTo:  "<original-id@test.com>",
+		References: []string{"<original-id@test.com>", "<even-older@test.com>"},
+	}
+
+	msg, err := email.Build()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	msgStr := string(msg)
+
+	if !strings.Contains(msgStr, "In-Reply-To: <original-id@test.com>") {
+		t.Error("missing In-Reply-To header")
+	}
+
+	if !strings.Contains(msgStr, "References: <original-id@test.com> <even-older@test.com>") {
+		t.Error("missing References header")
+	}
+}
+
+func TestComposeEmail_AllRecipients(t *testing.T) {
+	email := ComposeEmail{
+		To:  []domain.EmailAddress{{Email: "to@test.com"}},
+		CC:  []domain.EmailAddress{{Email: "cc@test.com"}},
+		BCC: []domain.EmailAddress{{Email: "bcc@test.com"}},
+	}
+
+	recipients := email.AllRecipients()
+
+	if len(recipients) != 3 {
+		t.Fatalf("expected 3 recipients, got %d", len(recipients))
+	}
+
+	expected := []string{"to@test.com", "cc@test.com", "bcc@test.com"}
+	for i, exp := range expected {
+		if recipients[i] != exp {
+			t.Errorf("expected recipient %d to be %s, got %s", i, exp, recipients[i])
+		}
+	}
+}
+
+func TestValidateEmail(t *testing.T) {
+	tests := []struct {
+		email   string
+		isValid bool
+	}{
+		{"user@example.com", true},
+		{"user.name@example.com", true},
+		{"user+tag@example.com", true},
+		{"user@subdomain.example.com", true},
+		{"invalid", false},
+		{"@example.com", false},
+		{"user@", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.email, func(t *testing.T) {
+			err := validateEmail(tt.email)
+			if tt.isValid && err != nil {
+				t.Errorf("expected %q to be valid, got error: %v", tt.email, err)
+			}
+			if !tt.isValid && err == nil {
+				t.Errorf("expected %q to be invalid", tt.email)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add `internal/composer` package for building RFC 2822 email messages
- `ComposeEmail` struct with all required fields (To, CC, BCC, Subject, Text, HTML, Attachments)
- Email address validation using `net/mail`
- Support for reply/forward threading headers

## Features
- Plain text emails
- HTML emails
- Multipart/alternative (text + html)
- Multipart/mixed (with attachments)
- Inline images with Content-ID
- Reply threading (In-Reply-To, References headers)
- `AllRecipients()` helper for SMTP

## Acceptance Criteria
- [x] Plain text email builds correctly
- [x] HTML + attachments build as multipart/mixed

## Tests
Comprehensive tests for validation and building various email types.