### PR TITLE
Story 7.4: Send Email Endpoint

### DIFF
--- a/internal/api/message_handler.go
+++ b/internal/api/message_handler.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -11,10 +13,12 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 
+	"github.com/oladayo21/letterbox/internal/composer"
 	"github.com/oladayo21/letterbox/internal/domain"
 	"github.com/oladayo21/letterbox/internal/imap"
 	"github.com/oladayo21/letterbox/internal/ingest"
 	"github.com/oladayo21/letterbox/internal/repository"
+	"github.com/oladayo21/letterbox/internal/smtp"
 	"github.com/oladayo21/letterbox/internal/storage"
 )
 
@@ -375,4 +379,288 @@ func (h *MessageHandler) GetMessage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, response)
+}
+
+// sendMessageRequest represents a request to send an email.
+type sendMessageRequest struct {
+	To          []domain.EmailAddress `json:"to" validate:"required,min=1,dive"`
+	CC          []domain.EmailAddress `json:"cc,omitempty"`
+	BCC         []domain.EmailAddress `json:"bcc,omitempty"`
+	Subject     string                `json:"subject" validate:"required"`
+	Text        string                `json:"text,omitempty"`
+	HTML        string                `json:"html,omitempty"`
+	Attachments []sendAttachmentInput `json:"attachments,omitempty"`
+}
+
+type sendAttachmentInput struct {
+	Filename    string `json:"filename" validate:"required"`
+	ContentType string `json:"content_type" validate:"required"`
+	Data        string `json:"data" validate:"required"` // Base64 encoded
+	IsInline    bool   `json:"is_inline,omitempty"`
+	ContentID   string `json:"content_id,omitempty"`
+}
+
+type sendMessageResponse struct {
+	MessageID string `json:"message_id"`
+	Success   bool   `json:"success"`
+}
+
+func (h *MessageHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
+	accountIDStr := chi.URLParam(r, "id")
+	accountID, err := uuid.Parse(accountIDStr)
+
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid account ID")
+
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, 25<<20) // 25MB limit for attachments
+
+	var req sendMessageRequest
+
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON")
+
+		return
+	}
+
+	if err := validate.Struct(req); err != nil {
+		writeError(w, http.StatusBadRequest, formatValidationError(err, sendMessageFieldNames))
+
+		return
+	}
+
+	// Require at least text or html
+	if req.Text == "" && req.HTML == "" {
+		writeError(w, http.StatusBadRequest, "at least text or html body is required")
+
+		return
+	}
+
+	// Get account with SMTP config
+	account, err := h.accountRepo.Get(r.Context(), accountID)
+
+	if errors.Is(err, repository.ErrAccountNotFound) {
+		writeError(w, http.StatusNotFound, "account not found")
+
+		return
+	}
+
+	if err != nil {
+		slog.Error("failed to get account", "account_id", accountID, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to get account")
+
+		return
+	}
+
+	// Check SMTP is configured
+	if account.SmtpHost == "" {
+		writeError(w, http.StatusBadRequest, "SMTP not configured for this account")
+
+		return
+	}
+
+	// Build attachments
+	attachments, err := parseAttachments(req.Attachments)
+
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+
+		return
+	}
+
+	// Compose the email
+	email := composer.ComposeEmail{
+		From: domain.EmailAddress{
+			Name:  account.Name,
+			Email: account.ImapUser, // Use IMAP user as from address
+		},
+		To:          req.To,
+		CC:          req.CC,
+		BCC:         req.BCC,
+		Subject:     req.Subject,
+		Text:        req.Text,
+		HTML:        req.HTML,
+		Attachments: attachments,
+	}
+
+	rawMessage, err := email.Build()
+
+	if err != nil {
+		slog.Error("failed to build email", "error", err)
+		writeError(w, http.StatusBadRequest, "failed to build email: "+err.Error())
+
+		return
+	}
+
+	// Send via SMTP
+	ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
+	defer cancel()
+
+	smtpCfg := smtp.Config{
+		Host:     account.SmtpHost,
+		Port:     account.SmtpPort,
+		Username: account.SmtpUser,
+		Password: account.SmtpPassword,
+	}
+
+	// Use IMAP user if SMTP user not set
+	if smtpCfg.Username == "" {
+		smtpCfg.Username = account.ImapUser
+		smtpCfg.Password = account.ImapPassword
+	}
+
+	err = smtp.SendEmail(ctx, smtpCfg, account.ImapUser, email.AllRecipients(), rawMessage)
+
+	if err != nil {
+		slog.Error("failed to send email", "account_id", accountID, "error", err)
+		writeError(w, http.StatusBadGateway, "failed to send email: "+classifySmtpError(err))
+
+		return
+	}
+
+	// Extract Message-ID from raw message for response
+	msgID := extractMessageID(rawMessage)
+
+	// Store sent email in local DB
+	go h.storeSentEmail(accountID, rawMessage, req, attachments)
+
+	slog.Info("email sent successfully", "account_id", accountID, "message_id", msgID, "recipients", len(email.AllRecipients()))
+
+	writeJSON(w, http.StatusOK, sendMessageResponse{
+		MessageID: msgID,
+		Success:   true,
+	})
+}
+
+func parseAttachments(inputs []sendAttachmentInput) ([]composer.Attachment, error) {
+	if len(inputs) == 0 {
+		return nil, nil
+	}
+
+	attachments := make([]composer.Attachment, len(inputs))
+
+	for i, input := range inputs {
+		data, err := decodeBase64(input.Data)
+
+		if err != nil {
+			return nil, errors.New("invalid base64 data for attachment: " + input.Filename)
+		}
+
+		attachments[i] = composer.Attachment{
+			Filename:    input.Filename,
+			ContentType: input.ContentType,
+			Data:        data,
+			IsInline:    input.IsInline,
+			ContentID:   input.ContentID,
+		}
+	}
+
+	return attachments, nil
+}
+
+func extractMessageID(raw []byte) string {
+	// Simple extraction - look for Message-Id header
+	lines := string(raw)
+
+	for _, prefix := range []string{"Message-Id: ", "Message-ID: ", "message-id: "} {
+		start := 0
+
+		for {
+			idx := indexAt(lines, prefix, start)
+
+			if idx == -1 {
+				break
+			}
+
+			end := idx + len(prefix)
+
+			for end < len(lines) && lines[end] != '\r' && lines[end] != '\n' {
+				end++
+			}
+
+			return lines[idx+len(prefix) : end]
+		}
+	}
+
+	return ""
+}
+
+func indexAt(s, substr string, start int) int {
+	if start >= len(s) {
+		return -1
+	}
+
+	idx := len(s[:start]) + len(substr)
+
+	if idx > len(s) {
+		idx = start
+	}
+
+	for i := start; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+
+	return -1
+}
+
+func (h *MessageHandler) storeSentEmail(accountID uuid.UUID, raw []byte, req sendMessageRequest, _ []composer.Attachment) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Parse the raw message to get Message-ID
+	msgID := extractMessageID(raw)
+
+	input := domain.CreateEmailInput{
+		AccountID:  accountID,
+		UID:        0, // Sent emails don't have IMAP UID
+		MessageID:  msgID,
+		Folder:     "Sent",
+		Subject:    req.Subject,
+		FromEmail:  "", // Will be set from account
+		FromName:   "",
+		To:         req.To,
+		CC:         req.CC,
+		Date:       time.Now(),
+		ParsedText: req.Text,
+		ParsedHTML: req.HTML,
+		Raw:        string(raw),
+		Flags:      []string{"\\Seen"},
+	}
+
+	// Get account for from address
+	account, err := h.accountRepo.Get(ctx, accountID)
+
+	if err == nil {
+		input.FromEmail = account.ImapUser
+		input.FromName = account.Name
+	}
+
+	_, err = h.emailRepo.Create(ctx, input)
+
+	if err != nil {
+		slog.Error("failed to store sent email", "account_id", accountID, "message_id", msgID, "error", err)
+	} else {
+		slog.Debug("stored sent email", "account_id", accountID, "message_id", msgID)
+	}
+}
+
+var sendMessageFieldNames = map[string]string{
+	"To":          "to",
+	"CC":          "cc",
+	"BCC":         "bcc",
+	"Subject":     "subject",
+	"Text":        "text",
+	"HTML":        "html",
+	"Attachments": "attachments",
+	"Filename":    "filename",
+	"ContentType": "content_type",
+	"Data":        "data",
+}
+
+func decodeBase64(s string) ([]byte, error) {
+	return base64.StdEncoding.DecodeString(s)
 }

--- a/internal/api/message_handler.go
+++ b/internal/api/message_handler.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -523,8 +524,15 @@ func (h *MessageHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 	// Extract Message-ID from raw message for response
 	msgID := extractMessageID(rawMessage)
 
-	// Store sent email in local DB
-	go h.storeSentEmail(accountID, rawMessage, req, attachments)
+	if msgID == "" {
+		slog.Warn("could not extract Message-ID from sent email", "account_id", accountID)
+	}
+
+	// Store sent email in local DB (synchronous to ensure storage)
+	if err := h.storeSentEmail(r.Context(), account, rawMessage, req); err != nil {
+		slog.Error("email sent but storage failed", "account_id", accountID, "message_id", msgID, "error", err)
+		// Still return success - email was sent, just not stored locally
+	}
 
 	slog.Info("email sent successfully", "account_id", accountID, "message_id", msgID, "recipients", len(email.AllRecipients()))
 
@@ -592,36 +600,27 @@ func indexAt(s, substr string, start int) int {
 		return -1
 	}
 
-	idx := len(s[:start]) + len(substr)
+	idx := strings.Index(s[start:], substr)
 
-	if idx > len(s) {
-		idx = start
+	if idx == -1 {
+		return -1
 	}
 
-	for i := start; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return i
-		}
-	}
-
-	return -1
+	return start + idx
 }
 
-func (h *MessageHandler) storeSentEmail(accountID uuid.UUID, raw []byte, req sendMessageRequest, _ []composer.Attachment) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
+func (h *MessageHandler) storeSentEmail(ctx context.Context, account *domain.Account, raw []byte, req sendMessageRequest) error {
 	// Parse the raw message to get Message-ID
 	msgID := extractMessageID(raw)
 
 	input := domain.CreateEmailInput{
-		AccountID:  accountID,
+		AccountID:  account.ID,
 		UID:        0, // Sent emails don't have IMAP UID
 		MessageID:  msgID,
 		Folder:     "Sent",
 		Subject:    req.Subject,
-		FromEmail:  "", // Will be set from account
-		FromName:   "",
+		FromEmail:  account.ImapUser,
+		FromName:   account.Name,
 		To:         req.To,
 		CC:         req.CC,
 		Date:       time.Now(),
@@ -631,21 +630,15 @@ func (h *MessageHandler) storeSentEmail(accountID uuid.UUID, raw []byte, req sen
 		Flags:      []string{"\\Seen"},
 	}
 
-	// Get account for from address
-	account, err := h.accountRepo.Get(ctx, accountID)
-
-	if err == nil {
-		input.FromEmail = account.ImapUser
-		input.FromName = account.Name
-	}
-
-	_, err = h.emailRepo.Create(ctx, input)
+	_, err := h.emailRepo.Create(ctx, input)
 
 	if err != nil {
-		slog.Error("failed to store sent email", "account_id", accountID, "message_id", msgID, "error", err)
-	} else {
-		slog.Debug("stored sent email", "account_id", accountID, "message_id", msgID)
+		return err
 	}
+
+	slog.Debug("stored sent email", "account_id", account.ID, "message_id", msgID)
+
+	return nil
 }
 
 var sendMessageFieldNames = map[string]string{

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -53,6 +53,7 @@ func NewRouter(cfg RouterConfig) *chi.Mux {
 			r.Get("/{id}/folders", folderHandler.List)
 			r.Get("/{id}/folders/{name}/messages", messageHandler.ListMessages)
 			r.Get("/{id}/messages/{uid}", messageHandler.GetMessage)
+			r.Post("/{id}/messages", messageHandler.SendMessage)
 		})
 
 		r.Route("/webhooks", func(r chi.Router) {


### PR DESCRIPTION
## Summary
Add `POST /accounts/{id}/messages` endpoint to send emails via SMTP.

## Features
- Send plain text or HTML emails
- Support for To, CC, BCC recipients
- Base64-encoded attachments (inline or regular)
- Stores sent email in local DB (Sent folder)
- Returns Message-ID on success

## Request Format
```json
{
  "to": [{"name": "Recipient", "email": "recipient@example.com"}],
  "cc": [],
  "bcc": [],
  "subject": "Hello",
  "text": "Plain text body",
  "html": "<p>HTML body</p>",
  "attachments": [
    {
      "filename": "doc.pdf",
      "content_type": "application/pdf",
      "data": "base64-encoded-data",
      "is_inline": false
    }
  ]
}
```

## Response Format
```json
{
  "message_id": "<uuid@letterbox>",
  "success": true
}
```

## Acceptance Criteria
- [x] Can send plain text email via API
- [x] Can send HTML email with attachments
- [x] Sent email appears in local mirror